### PR TITLE
Fix trailing comments at end of file

### DIFF
--- a/lib/Format.hs
+++ b/lib/Format.hs
@@ -702,12 +702,21 @@ doStatement log indentation indent' doStatement' = case doStatement' of
     let
       indent = indent' <> indentation
     debug log "DoLet" doStatement' (Span.doStatement doStatement')
-    sourceToken log indent' blank let'
-      <> foldMap
-        (letBinding log indentation indent (newline <> indent) blank)
-        (Data.List.NonEmpty.init letBindings)
-      <> (letBinding log indentation indent (newline <> indent) blank)
-        (Data.List.NonEmpty.last letBindings)
+    case letBindings of
+      (Language.PureScript.CST.LetBindingName Span.SingleLine _) Data.List.NonEmpty.:| [] -> 
+        sourceToken log indent' blank let' <> (letBinding log indentation indent space blank) (Data.List.NonEmpty.head letBindings)
+      (Language.PureScript.CST.LetBindingPattern Span.SingleLine _ _ _) Data.List.NonEmpty.:| [] -> 
+        sourceToken log indent' blank let' <> (letBinding log indentation indent space blank) (Data.List.NonEmpty.head letBindings)
+      -- Can this even happen?
+      (Language.PureScript.CST.LetBindingSignature Span.SingleLine _) Data.List.NonEmpty.:| [] -> 
+        sourceToken log indent' blank let' <> (letBinding log indentation indent space blank) (Data.List.NonEmpty.head letBindings)
+      _ ->
+        sourceToken log indent' blank let'
+          <> foldMap
+            (letBinding log indentation indent (newline <> indent) blank)
+            (Data.List.NonEmpty.init letBindings)
+          <> (letBinding log indentation indent (newline <> indent) blank)
+            (Data.List.NonEmpty.last letBindings)
 
 export ::
   Log.Handle ->

--- a/lib/Format.hs
+++ b/lib/Format.hs
@@ -386,6 +386,46 @@ commentsTrailing log f prefix commentsTrailing' = case commentsTrailing' of
     debug log "trailing comments" commentsTrailing' Span.MultipleLines
     foldMap (commentTrailing log f prefix) commentsTrailing'
 
+commentTrailingFile ::
+  (Show a) =>
+  Log.Handle ->
+  (a -> Span.Span) ->
+  Prefix ->
+  Language.PureScript.CST.Comment a ->
+  IO Utf8Builder
+commentTrailingFile log f prefix comment'' = case comment'' of
+  Language.PureScript.CST.Comment comment' -> do
+    debug log "Comment" comment'' (Span.comment f comment'')
+    pure (prefix <> display comment')
+  Language.PureScript.CST.Line _ -> do
+    Log.debug log "Not formatting `Line`"
+    pure blank
+  Language.PureScript.CST.Space _ -> do
+    Log.debug log "Not formatting `Space`"
+    pure blank
+
+commentsTrailingFile ::
+  (Show a) =>
+  Log.Handle ->
+  (a -> Span.Span) ->
+  Prefix ->
+  [Language.PureScript.CST.Comment a] ->
+  IO Utf8Builder
+commentsTrailingFile log f prefix commentsTrailing' = 
+  case commentsTrailing'' of
+  [] -> do
+    Log.debug log "No trailing comments to format"
+    pure blank
+  _ -> do
+    debug log "trailing comments" commentsTrailing' Span.MultipleLines
+    (foldMap (commentTrailingFile log f prefix) commentsTrailing'') <> pure newline
+  where
+    isWhiteSpace ct = case ct of 
+      Language.PureScript.CST.Comment _ -> False
+      Language.PureScript.CST.Line _ -> True
+      Language.PureScript.CST.Space _ -> True
+    commentsTrailing'' = List.dropWhileEnd isWhiteSpace commentsTrailing'
+
 constraint ::
   Log.Handle ->
   Indentation ->
@@ -1576,7 +1616,7 @@ module' log indentation module''' = case module''' of
       <> pure newline
       <> imports log indentation imports'
       <> declarations log indentation declarations'
-      <> commentsTrailing log Span.lineFeed blank trailing
+      <> commentsTrailingFile log Span.lineFeed newline trailing
 
 name ::
   Log.Handle ->

--- a/test/golden/files/formatted/Ado.purs
+++ b/test/golden/files/formatted/Ado.purs
@@ -1,8 +1,7 @@
 module Ado where
 
 foo = ado
-  let
-    w = 0
+  let w = 0
   x <- pure 1
   y <- do
     pure 2

--- a/test/golden/files/formatted/Comments.purs
+++ b/test/golden/files/formatted/Comments.purs
@@ -38,3 +38,7 @@ x = X
 {- A block comment on a type -}
 y ∷ Y -> Y -> Y
 y _ _ = Y
+
+-- Some commented code at the end of the file
+-- z :: 25
+-- z = 12

--- a/test/golden/files/formatted/Let.purs
+++ b/test/golden/files/formatted/Let.purs
@@ -3,8 +3,7 @@ module Let where
 import Prelude
 
 shortLet = do
-  let
-    x = 12
+  let x = 12
   pure x
 
 foo =

--- a/test/golden/files/original/Comments.purs
+++ b/test/golden/files/original/Comments.purs
@@ -37,3 +37,7 @@ x = X
 {- A block comment on a type -}
 y :: Y -> Y -> Y
 y _ _ = Y
+
+-- Some commented code at the end of the file
+-- z :: 25
+-- z = 12


### PR DESCRIPTION
This fixes the comments at the end of a file. Depends on #3 