### PR TITLE
Where binding with multiple definitions (different patterns)

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -69,6 +69,7 @@ library:
     - purescript == 0.13.2
     - rio == 0.1.9.2
     - text == 1.2.3.1
+    - semigroupoids == 5.3.4
   source-dirs: lib
 license: BSD3
 maintainer: jones3.hardy@gmail.com

--- a/test/golden/files/formatted/Where.purs
+++ b/test/golden/files/formatted/Where.purs
@@ -11,6 +11,6 @@ foo = withoutType1
 
     withoutType3 = 1
 
-    withType2 ∷ Int
+    withType2 ∷ Int -> Int
     withType2 1 = 41
     withType2 _ = 42

--- a/test/golden/files/formatted/Where.purs
+++ b/test/golden/files/formatted/Where.purs
@@ -12,4 +12,5 @@ foo = withoutType1
     withoutType3 = 1
 
     withType2 ∷ Int
-    withType2 = 3
+    withType2 1 = 41
+    withType2 _ = 42

--- a/test/golden/files/original/Where.purs
+++ b/test/golden/files/original/Where.purs
@@ -5,10 +5,11 @@ foo = withoutType1
     withoutType1 = 1
     withoutType2 = 1
 
-    withType1 :: Int
     withType1 = 3
+    withType1 :: Int
 
     withoutType3 = 1
 
     withType2 :: Int
-    withType2 = 3
+    withType2 1 = 41
+    withType2 _ = 42

--- a/test/golden/files/original/Where.purs
+++ b/test/golden/files/original/Where.purs
@@ -10,6 +10,6 @@ foo = withoutType1
 
     withoutType3 = 1
 
-    withType2 :: Int
+    withType2 :: Int -> Int
     withType2 1 = 41
     withType2 _ = 42


### PR DESCRIPTION
I noticed where clauses don't group the bindings as one would expect. Example:
```
where
  f :: Int -> Int
  f 0 = 0
  f _ = 42
```

ends up being formatted as:
```
where
  f :: Int -> Int
  f 0 = 0

  f _ = 42
```

The Purescript AST represents this as 3 different bindings (1 for the type signatures and 2 different function definitions).

This PR groups the bindings by name and doesn't generate the empty line for definitions of the same symbol (see included test case).